### PR TITLE
Read from global catchments file

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,13 +98,12 @@ To simply try the program with the sample data provided, you can skip to step 5.
 When you are ready to try with your own locations, you will need to download additional 
 data as described in steps 1 and 2.
 
-1. [Download basin-scale MERIT-Hydro raster data (mghydro.com)](#step1)
-2. [Download MERIT-Basins vector data (reachhydro.com)](#step2)
-3. [Create a CSV file with your desired watershed outlet points](#step4)
-4. [Edit settings in `config.py`](#step5)
-5. [Run `subbasins.py` to delineate watersheds](#step6)
-6. [Review output](#step7)
-7. [Run again to fix mistakes (repeat steps 4 – 7)](#step8)
+1. [Download basin-scale MERIT-Hydro raster data (mghydro.com)](#step_download)
+1. [Create a CSV file with your desired watershed outlet points](#step_csv)
+1. [Edit settings in `config.py`](#step_config)
+1. [Run `subbasins.py` to delineate watersheds](#step_run)
+1. [Review output](#step_review)
+1. [Run again to fix mistakes (repeat steps 4 – 7)](#step_repeat)
 
 Before you begin downloading the data in steps 1 and 2, determine which files you need based on your region of interest. 
 The data files are organized into continental-scale river basins, or Pfafstetter Level 2 basins. 
@@ -115,7 +114,7 @@ MERIT Level 2 megabasins
 
 # Detailed Instructions
 
-## <a name="step1">1. Download MERIT-Hydro raster data</a>
+## <a name="step_download">Download MERIT-Hydro raster data</a>
 
 You will need two sets of MERIT-Hydro gridded (or raster) data: **flow accumulation**
 and **flow direction**. 
@@ -131,29 +130,7 @@ Modify these variables:
 - `MERIT_ACCUM_DIR` (for flow accumulation)
 
 
-## 2. <a name="step2">Download MERIT-Basins vector data</a>
-
-Download the shapefiles for unit catchments and river reaches from the creators of MERIT-Basins. 
-Follow the instructions here:
-[https://www.reachhydro.org/home/params/merit-basins](https://www.reachhydro.org/home/params/merit-basins)
-
-In the folder `pfaf_level_02` , download two sets of files:
-
-1. unit catchment shapefiles: `cat_pfaf_##_MERIT_Hydro_v07_Basins_v01.shp`
-2. river reach shapefiles: `riv_pfaf_##_MERIT_Hydro_v07_Basins_v01.shp`
-
-In these files, `##` is the Pfafstetter Level 2 basin code. 
-See the figure above to determine which of the 61 level 2 basins you need, 
-depending on your region of interest. 
-
-(**Note**: Do NOT download the files marked 'bugfix' from MERIT-Basins. These files cause
-errors for some reason.)
-
-Unzip these files and save them to a folder on your hard drive. 
-Then, in `config.py`, update the variables 
-`CATCHMENTS_DIR` and `RIVERS_DIR` to tell the script where to find these data.
-
-## <a name="step4">3. Create a CSV file with your desired watershed outlet points</a>
+## <a name="step_csv">Create a CSV file with your desired watershed outlet points</a>
 
 The script reads information about your desired watershed outlet points from a 
 plain-text comma-delimited (CSV) file. Edit this file carefully, as the script will 
@@ -198,13 +175,13 @@ All latitude and longitude coordinates should be in decimal degrees
 In this example, there are two *main* outlets. The first, "foz-tua," has two subbasin
 outlets. The second, "baixo-sabor," has one subbasin outlet. 
 
-## <a name="step5">4. Update `config.py`</a>
+## <a name="step_config">Update `config.py`</a>
 
 Read through the options and set the variables as you wish. 
 Make sure to set the correct folder paths to where you are storing 
 the input data on your computer.
 
-## <a name="step6">5. Run `subbasins.py` to delineate watersheds</a>
+## <a name="step_run">Run `subbasins.py` to delineate watersheds</a>
 
 Once you have downloaded the datasets listed above, and updated `config.py`, 
 you are ready to delineate watersheds. The script takes exactly two arguments:
@@ -236,7 +213,7 @@ or via the console:
 >> delineate('outlets.csv', 'testrun')
 ```
 
-## <a name="step7">6. Review results</a>
+## <a name="step_review">Review results</a>
 
 The script can output several different geodata formats, 
 as long as the format is supported by `GeoPandas`. Shapefiles are popular, 
@@ -247,7 +224,7 @@ To get a full list of available formats, follow the directions
 (see Supported Drivers).
 
 
-## <a name="step8">7. Run again to fix any mistakes</a>
+## <a name="step_repeat">Run again to fix any mistakes</a>
 
 Automated watershed delineation is often incorrect. 
 The good news is that errors can often be fixed by slightly moving the 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ data as described in steps 1 and 2.
 1. [Edit settings in `config.py`](#step_config)
 1. [Run `subbasins.py` to delineate watersheds](#step_run)
 1. [Review output](#step_review)
-1. [Run again to fix mistakes (repeat steps 4 – 7)](#step_repeat)
+1. [Run again to fix mistakes](#step_repeat)
 
 Before you begin downloading the data in steps 1 and 2, determine which files you need based on your region of interest. 
 The data files are organized into continental-scale river basins, or Pfafstetter Level 2 basins. 

--- a/config.py
+++ b/config.py
@@ -18,11 +18,6 @@ VERBOSE = True
 #MERIT_FDIR_DIR = r"C:\Data\GIS\MERITHydro\flow_dir_basins"
 MERIT_FDIR_DIR = "data/raster/flowdir_basins"
 
-# Folder where you have stored the Merit-BASINS unit catchment shapefiles.
-# These files need to be downloaded from: https://www.reachhydro.org/home/params/merit-basins
-#CATCHMENTS_DIR = r"C:\Data\GIS\MERITBasins\catchments\src"
-CATCHMENTS_DIR = "data/shp/merit_catchments"
-
 # Folder where the script will write the output geodata
 OUTPUT_DIR = "output"
 

--- a/py/util.py
+++ b/py/util.py
@@ -14,7 +14,7 @@ import re
 import pickle
 import warnings
 import matplotlib.pyplot as plt
-from config import PICKLE_DIR, OUTPUT_DIR, VERBOSE, OUTPUT_EXT, CATCHMENTS_DIR, PLOTS_DIR
+from config import PICKLE_DIR, OUTPUT_DIR, VERBOSE, OUTPUT_EXT, PLOTS_DIR
 from numpy import random
 
 # The WGS84 projection string, used in a few places
@@ -367,7 +367,6 @@ def load_gdf(geotype: str, high_resolution: bool, bounds: tuple) -> gpd.GeoDataF
         if os.path.isfile(pickle_fname):
             if VERBOSE: print(f"Loading BASIN catchment data from pickle file.")
             gdf = pickle.load(open(pickle_fname, "rb"))
-            breakpoint()
             return gdf
 
     # Open the shapefile for the bounds

--- a/py/util.py
+++ b/py/util.py
@@ -323,16 +323,16 @@ def make_folders():
             raise Exception(f"Could not create folder `{folder}`. Stopping")
 
 
-def get_pickle_filename(geotype: str, basin: int, high_resolution: bool) -> str:
+def get_pickle_filename(geotype: str, bounds: tuple, high_resolution: bool) -> str:
     """Simple function to get the standard filename for the pickle files used by this project.
     The filenames look like this:
-       PICKLE_DIR/catchments_##_hires.pkl
-       PICKLE_DIR/catchments_##_lores.pkl
+       PICKLE_DIR/catchments_##_##_##_##_hires.pkl
+       PICKLE_DIR/catchments_##_##_##_##_lores.pkl
 
-       PICKLE_DIR/rivers_##_hires.pkl
-       PICKLE_DIR/rivers_##_lores.pkl
+       PICKLE_DIR/rivers_##_##_##_##_hires.pkl
+       PICKLE_DIR/rivers_##_##_##_##_lores.pkl
 
-    where ## is the megabasin number (11-91)
+    where ## is a coord in bounds
 
     """
 
@@ -340,11 +340,12 @@ def get_pickle_filename(geotype: str, basin: int, high_resolution: bool) -> str:
         resolution_str = 'hires'
     else:
         resolution_str = 'lores'
-    fname = f'{PICKLE_DIR}/{geotype}_{basin}_{resolution_str}.pkl'
+    bounds_str = '_'.join(map(str, bounds))
+    fname = f'{PICKLE_DIR}/{geotype}_{bounds_str}_{resolution_str}.pkl'
     return fname
 
 
-def load_gdf(geotype: str, basin: int, high_resolution: bool, bounds: tuple) -> gpd.GeoDataFrame:
+def load_gdf(geotype: str, high_resolution: bool, bounds: tuple) -> gpd.GeoDataFrame:
     """
     Returns the unit catchments vector polygon dataset as a GeoDataFrame
     Gets the data from the MERIT-Basins shapefile the first time,
@@ -362,16 +363,17 @@ def load_gdf(geotype: str, basin: int, high_resolution: bool, bounds: tuple) -> 
 
     # First, check for the presence of a pickle file
     if PICKLE_DIR != '':
-        pickle_fname = get_pickle_filename(geotype, basin, high_resolution)
+        pickle_fname = get_pickle_filename(geotype, bounds, high_resolution)
         if os.path.isfile(pickle_fname):
-            if VERBOSE: print(f"Loading BASIN # {basin} catchment data from pickle file.")
+            if VERBOSE: print(f"Loading BASIN catchment data from pickle file.")
             gdf = pickle.load(open(pickle_fname, "rb"))
+            breakpoint()
             return gdf
 
-    # Open the shapefile for the basin
+    # Open the shapefile for the bounds
     if geotype == "catchments":
         directory = CATCHMENTS_DIR
-        gis_file = f"{directory}/cat_pfaf_{basin}_MERIT_Hydro_v07_Basins_v01.shp"
+        gis_file = "https://pub-5f26e013d22e454ea079891d13f905f1.r2.dev/global_catchments.fgb"
     elif geotype == "rivers":
         gis_file = "https://pub-5f26e013d22e454ea079891d13f905f1.r2.dev/global_flowlines.fgb"
 
@@ -382,12 +384,12 @@ def load_gdf(geotype: str, basin: int, high_resolution: bool, bounds: tuple) -> 
     gdf.set_crs(PROJ_WGS84, inplace=True, allow_override=True)
 
     # Before we exit, save the GeoDataFrame as a pickle file, for future speedups!
-    save_pickle(geotype, gdf, basin, high_resolution)
+    save_pickle(geotype, gdf, high_resolution, bounds)
 
     return gdf
 
 
-def save_pickle(geotype: str, gdf: gpd.GeoDataFrame, basin: int, high_resolution: bool):
+def save_pickle(geotype: str, gdf: gpd.GeoDataFrame, high_resolution: bool, bounds: tuple):
     # If we loaded the catchments from a shapefile, save the gdf to a pickle file for future speedup
     if PICKLE_DIR != '':
 
@@ -399,7 +401,7 @@ def save_pickle(geotype: str, gdf: gpd.GeoDataFrame, basin: int, high_resolution
             gdf.sindex.create_index()
 
         # Get the standard project filename for the pickle files.
-        pickle_fname = get_pickle_filename(geotype, basin, high_resolution)
+        pickle_fname = get_pickle_filename(geotype, bounds, high_resolution)
         if not os.path.isfile(pickle_fname):
             if VERBOSE: print(f"Saving GeoDataFrame to pickle file: {pickle_fname}")
             try:

--- a/subbasins.py
+++ b/subbasins.py
@@ -123,13 +123,13 @@ def delineate(input_csv: str, output_prefix: str):
         # Iterate over the outlets:
         outlets = gage_basins_dict[megabasin]
 
-        if VERBOSE: print('Reading geodata for unit catchments in megabasin %s' % megabasin)
-        catchments_gdf = load_gdf("catchments", megabasin, True, bounds)
+        if VERBOSE: print(f'Reading geodata for unit catchments with bounds {bounds}')
+        catchments_gdf = load_gdf("catchments", True, bounds)
 
         # The _network_ data is in the RIVERS file rather than the CATCHMENTS file
         # (this is just how the MERIT-Basins authors did it)
-        if VERBOSE: print('Reading geodata for rivers in megabasin %s' % megabasin)
-        rivers_gdf = load_gdf("rivers", megabasin, True, bounds)
+        if VERBOSE: print(f'Reading geodata for rivers with bounds {bounds}')
+        rivers_gdf = load_gdf("rivers", True, bounds)
         rivers_gdf.set_index('COMID', inplace=True)
         # We wish to report the outlet point for each subbasin.
         # We can get this information from end point of the river polylines.


### PR DESCRIPTION
while i was in there, i also cleaned up some refs to megabasins and basins that are now obolete and removed the vector data download step from the readme

open question: to speed up reads, do we want to use canonical bounds (eg bounds that match up with tiles?) we might read more data than we need, but caching could make things faster? 