### PR TITLE
[update] add pyogrio to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "numpy==1.*",
     "pandas>=1.3",
     "pillow==10.*",
+    "pyogrio>0",
     "pyproj==3.*",
     "pysheds>=0.3",
     "scipy==1.*",


### PR DESCRIPTION
So lower versions of geopandas that don't have it installed by default can use this package 