### PR TITLE
Allow config overrides in script

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ data as described in steps 1 and 2.
 
 1. [Export env vars pointing to raster and vector data](#step_env)
 1. [Create a CSV file with your desired watershed outlet points](#step_csv)
-1. [Override config defaults](#step_config)
 1. [Delineate watersheds](#step_run)
 1. [Review output](#step_review)
 1. [Run again to fix mistakes](#step_repeat)
@@ -169,16 +168,6 @@ All latitude and longitude coordinates should be in decimal degrees
 In this example, there are two *main* outlets. The first, "foz-tua," has two subbasin
 outlets. The second, "baixo-sabor," has one subbasin outlet. 
 
-## <a name="step_config">Override config defaults</a>
-
-Read through the options in `config.py`, then override any variables as you wish. 
-
-``` python
-graph, subbasins_gdf, rivers_gdf = delineate(
-    csv_filename, output_prefix, {"WRITE_OUTPUT": True, "NETWORK_DIAGRAMS": True}
-)
-```
-
 ## <a name="step_run">Delineate watersheds</a>
 
 Delineation can be run from the command line, or from Python. Either way, you will need to specify a few arguments:
@@ -187,19 +176,19 @@ Delineation can be run from the command line, or from Python. Either way, you wi
 - `output_prefix` (required) - Output prefix, a string. The output files will start with this string. For 
 example, 
 if you provide 'shasta', the script will produce `shasta_subbasins.shp`, `shasta_outlets.shp`, etc.
-- `config_overrides` (optional, Python-only) - A dictionary of overrides. Eg to turn `VERBOSE` logging on or off.
+- `config_vals` (optional) - Override default settings. Eg to turn `VERBOSE` logging on or off.
 
 You can run the script from the command line like this:
 
 ``` bash
-python upstream_delineator/scripts/subbasins.py /path/to/file/outlets.csv shasta
+python upstream_delineator/scripts/subbasins.py /path/to/file/outlets.csv shasta --PLOTS --NO_VERBOSE --MAX_AREA 250
 ```
 
 Alternatively, you can call the delineation routine from Python:
 
 ``` python
 >> from upstream_delineator.delineator_utils.delineate import delineate
->> delineate('/path/to/file/outlets.csv', 'shasta')
+>> delineate('/path/to/file/outlets.csv', 'shasta', {"PLOTS": True, "VERBOSE": False, "MAX_AREA": 250})
 ```
 
 ## <a name="step_review">Review results</a>

--- a/upstream_delineator/scripts/subbasins.py
+++ b/upstream_delineator/scripts/subbasins.py
@@ -26,12 +26,13 @@ or in Python as follows:
 import argparse
 import sys
 sys.path.insert(0, ".")
+import inspect
 
 # My stuff
 from upstream_delineator.delineator_utils.delineate import delineate
 
 
-def _run_from_terminal():
+def run():
     """
     Routine which is run when you call subbasins.py from the command line.
     should be run like:
@@ -62,8 +63,17 @@ def main():
 
 
 if __name__ == "__main__":
-    if len(sys.argv) > 1:
-        # Run with command-line arguments
-        _run_from_terminal()
-    else:
-        main()
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument("--org-id", required=True)
+    argparser.add_argument(
+        "input_csv",
+        help="CSV of outlets to delineate.",
+    )
+    argparser.add_argument(
+        "output_prefix",
+        help="Prefix for output files from this run.",
+    )
+    args = argparser.parse_args()
+    parameters = inspect.signature(run).parameters
+    kwargs = {k: v for k, v in vars(args).items() if k in parameters}
+    run(**kwargs)

--- a/upstream_delineator/scripts/subbasins.py
+++ b/upstream_delineator/scripts/subbasins.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     for key, val in vars(args).items():
         if key in _GLOBAL_CONFIG:
             config_vals[key] = val 
-        elif key.removeprefix("NO_") in _GLOBAL_CONFIG:
-            config_vals[key.removeprefix("NO_")] = not val 
+        elif (stripped_key := key.removeprefix("NO_")) in _GLOBAL_CONFIG:
+            config_vals[stripped_key] = not val 
     
     delineate(args.input_csv, args.output_prefix, config_vals=config_vals)


### PR DESCRIPTION
to make testing easier (no more fiddling with the config file!)

we can now run things like 
``` bash
python upstream_delineator/scripts/subbasins.py outlets.csv test_script --NO_VERBOSE --PLOTS --MAX_AREA 200
```