### PR TITLE
[update] test csv cols to match master

### DIFF
--- a/outlets.csv
+++ b/outlets.csv
@@ -1,6 +1,6 @@
-id,lng,lat,name,is_outlet
-1,-14.36201,65.50253,Lagarfljot River at Lagarfoss,true
-2,-15.0883,64.9839,Jokulsa I River at Fljotsdal Holl,false
-3,-14.533,65.14,Gringa Dam,false
-4,-14.481,65.328,Route 1 over Ranga,false
-5,-15.186,64.735,Lake Sauoarvatr outlet,false
+id,lng,lat,name,outlet_id
+1,-14.36201,65.50253,Lagarfljot River at Lagarfoss,1
+2,-15.0883,64.9839,Jokulsa I River at Fljotsdal Holl,1
+3,-14.533,65.14,Gringa Dam,1
+4,-14.481,65.328,Route 1 over Ranga,1
+5,-15.186,64.735,Lake Sauoarvatr outlet,1


### PR DESCRIPTION
follow up from https://github.com/Upstream-Tech/delineator/pull/17 


# testing 
```
(venv) tngzng@tzhang:~/delineator$ python upstream_delineator/scripts/subbasins.py outlets.csv test_outlets_csv
Reading your outlets data in: outlets.csv
Loading BASIN catchment data from pickle file.
Finding out which Pfafstetter Level 2 'megabasin' your outlets are in
Reading geodata for unit catchments with bounds (-24.36375, 63.392916666666665, -13.619583333333333, 66.50541666666666)
Loading BASIN catchment data from pickle file.
Reading geodata for rivers with bounds (-24.36375, 63.392916666666665, -13.619583333333333, 66.50541666666666)
Loading BASIN catchment data from pickle file.
Performing overlay analysis on 5 outlet points in basin #27
Delineating catchment 1
Delineating catchment 2
Delineating catchment 3
Delineating catchment 4
Delineating catchment 5
/home/tngzng/delineator/venv/lib/python3.10/site-packages/geopandas/array.py:1638: UserWarning: CRS not set for some of the concatenation inputs. Setting output's CRS as WGS 84 (the single non-null crs provided).
  return GeometryArray(data, crs=_get_common_crs(to_concat))
Creating Network GRAPH
Summary statistics for subbasin areas:
n  | Median | Mean | Std. Dev. | CV  | Skew
59,    39,   52.7,    37.5,   0.712,   1.36
Pruned 1 empty unit catchments from the river network.
[27000761]
Ran successfully!
```