### PR TITLE
[fix] refer to plots dir arg instead of hardcoding

### DIFF
--- a/upstream_delineator/delineator_utils/consolidate.py
+++ b/upstream_delineator/delineator_utils/consolidate.py
@@ -355,22 +355,22 @@ def consolidate_network(G: nx.DiGraph, threshold_area: float or int) -> Tuple[nx
     rivers2merge = {}
     rivers2delete = []
 
-    if DRAW_NET_DIAGRAM: draw_graph(G, filename='plots/test_net', title="Original Network")
+    if DRAW_NET_DIAGRAM: draw_graph(G, filename=f'{config.get("PLOTS_DIR")}/test_net', title="Original Network")
     if config.get("VERBOSE"):
         print(f"Consolidating river network. Max. subbasin area: {threshold_area}")
         print('Iteration #1')
 
     # Step 1, merge leaves with their downstream node
     G, MERGES, rivers2merge, rivers2delete = trim_clusters(G, threshold_area, MERGES, rivers2merge, rivers2delete)
-    if DRAW_NET_DIAGRAM: draw_graph(G, filename='plots/test_pruned', title="Pruned Network after Step 1")
+    if DRAW_NET_DIAGRAM: draw_graph(G, filename=f'{config.get("PLOTS_DIR")}/test_pruned', title="Pruned Network after Step 1")
 
     # Step 2, merge stems
     G, MERGES, rivers2merge = collapse_stems(G, threshold_area, MERGES, rivers2merge)
-    if DRAW_NET_DIAGRAM: draw_graph(G, filename='plots/test_step2', title="Stems merged, after Step 2")
+    if DRAW_NET_DIAGRAM: draw_graph(G, filename=f'{config.get("PLOTS_DIR")}/test_step2', title="Stems merged, after Step 2")
 
     # Step #3, prune small solo leaves
     G, MERGES, rivers2merge, rivers2delete = prune_leaves(G, threshold_area, MERGES, rivers2merge, rivers2delete)
-    if DRAW_NET_DIAGRAM: draw_graph(G, filename='plots/test_step4', title="Small solo leaves pruned, after Step 4")
+    if DRAW_NET_DIAGRAM: draw_graph(G, filename=f'{config.get("PLOTS_DIR")}/test_step4', title="Small solo leaves pruned, after Step 4")
 
     # Iterate through the consolidation steps until the network stops changing
     i = 1  # Counter to keep track of how many iterations we do
@@ -390,7 +390,7 @@ def consolidate_network(G: nx.DiGraph, threshold_area: float or int) -> Tuple[nx
     # Final step, takes care of any remaining small stem nodes
     G, MERGES, rivers2merge = last_merge(G, threshold_area, MERGES, rivers2merge)
 
-    if DRAW_NET_DIAGRAM:  draw_graph(G, filename='plots/test_step5', title="After iteration, Step 5")
+    if DRAW_NET_DIAGRAM:  draw_graph(G, filename=f'{config.get("PLOTS_DIR")}/test_step5', title="After iteration, Step 5")
     if config.get("VERBOSE"): show_area_stats(G)
 
     return G, MERGES, rivers2merge, rivers2delete

--- a/upstream_delineator/delineator_utils/delineate.py
+++ b/upstream_delineator/delineator_utils/delineate.py
@@ -148,7 +148,7 @@ def delineate(input_csv: str, output_prefix: str, config_vals: dict = None, csv_
         write_outputs(G, myrivers_gdf, subbasins_gdf, gages_list, output_prefix)
 
     if config.get("NETWORK_DIAGRAMS"):
-        draw_graph(G, f'plots/{output_prefix}_network_final')
+        draw_graph(G, f'{config.get("PLOTS_DIR")}/{output_prefix}_network_final')
 
     print("Ran successfully!")
     return G, subbasins_gdf, myrivers_gdf
@@ -254,7 +254,7 @@ def get_watershed(gages_gdf: gpd.GeoDataFrame, megabasin: int, catchments_gdf, r
 
     # For debugging mostly
     # G = make_river_network(subbasins_gdf, terminal_comid)
-    # if config.get("NETWORK_DIAGRAMS"): draw_graph(G, f'plots/{OUTPUT_PREFIX}_network_before')
+    # if config.get("NETWORK_DIAGRAMS"): draw_graph(G, f'{config.get("PLOTS_DIR")}/{OUTPUT_PREFIX}_network_before')
 
     # Create two copies of river network data!
     # `allrivers_gdf` will contain all the available polylines in the watershed, a nice
@@ -313,7 +313,7 @@ def get_watershed(gages_gdf: gpd.GeoDataFrame, megabasin: int, catchments_gdf, r
         G.nodes[gage]['custom'] = True
 
     # Draw the network before consolidating? Mostly useful for debugging.
-    # if config.get("NETWORK_DIAGRAMS"): draw_graph(G, f'plots/{OUTPUT_PREFIX}_premerge')
+    # if config.get("NETWORK_DIAGRAMS"): draw_graph(G, f'{config.get("PLOTS_DIR")}/{OUTPUT_PREFIX}_premerge')
 
     # CHECK FOR Null Geometries.
     # If the user has placed one of their points very close to an existing basin outlet,
@@ -329,7 +329,7 @@ def get_watershed(gages_gdf: gpd.GeoDataFrame, megabasin: int, catchments_gdf, r
     if len(null_nodes) > 0:
         if config.get("VERBOSE"): print(f"Pruned {len(null_nodes)} empty unit catchments from the river network.")
         print(null_nodes)
-        # if config.get("NETWORK_DIAGRAMS"): draw_graph(G, f'plots/{OUTPUT_PREFIX}_network_pruned')
+        # if config.get("NETWORK_DIAGRAMS"): draw_graph(G, f'{config.get("PLOTS_DIR")}/{OUTPUT_PREFIX}_network_pruned')
 
     null_rivers = myrivers_gdf.index[myrivers_gdf['geometry'].is_empty].tolist()
     myrivers_gdf.drop(null_rivers, inplace=True)
@@ -359,7 +359,7 @@ def get_watershed(gages_gdf: gpd.GeoDataFrame, megabasin: int, catchments_gdf, r
     # I call this "consolidating the river network."
     if config.get("CONSOLIDATE"):
         G, MERGES, rivers2merge, rivers2delete = consolidate_network(G, threshold_area=config.get("MAX_AREA"))
-        # if config.get("NETWORK_DIAGRAMS"): draw_graph(G, f'plots/{OUTPUT_PREFIX}_network_final')
+        # if config.get("NETWORK_DIAGRAMS"): draw_graph(G, f'{config.get("PLOTS_DIR")}/{OUTPUT_PREFIX}_network_final')
         subbasins_gdf['target'] = subbasins_gdf.index
 
         # Dissolve unit catchments based on information in MERGES.

--- a/upstream_delineator/delineator_utils/raster_plots.py
+++ b/upstream_delineator/delineator_utils/raster_plots.py
@@ -8,6 +8,8 @@ import numpy as np
 from matplotlib import colors, rc
 from matplotlib.colors import LogNorm
 
+from upstream_delineator import config
+
 font = {'weight': 'normal',
         'size': 18}
 
@@ -23,8 +25,8 @@ def plot_mask(mask, catchment_poly, lat, lng, wid):
     plt.scatter(x=lng, y=lat, c='red', edgecolors='black')
     plt.colorbar(label='Terminal Unit Catchment', fraction=0.06, pad=0.06)
 
-    plt.title("Mask for the unit catchment for watershed id = {}".format(wid))
-    plt.savefig('plots/{}_raster_mask.jpg'.format(wid))
+    plt.title(f"Mask for the unit catchment for watershed id = {wid}")
+    plt.savefig(f'{config.get("PLOTS_DIR")}/{wid}_raster_mask.jpg')
     plt.close(fig)
 
 
@@ -38,8 +40,8 @@ def plot_flowdir(fdir, lat, lng, wid, dirmap, catchment_poly):
     plt.xlabel('Longitude')
     plt.ylabel('Latitude')
     plt.scatter(x=lng, y=lat, c='red', edgecolors='black')
-    plt.title('Flow direction grid for watershed id ={}'.format(wid))
-    plt.savefig("plots/{}_raster_flowdir.jpg".format(wid))
+    plt.title(f'Flow direction grid for watershed id = {wid}')
+    plt.savefig(f"{config.get('PLOTS_DIR')}/{wid}_raster_flowdir.jpg")
     plt.close(fig)
 
 
@@ -54,10 +56,10 @@ def plot_accum(acc, lat, lng, lat_snap, lng_snap, wid, catchment_poly):
     plt.plot(*catchment_poly.exterior.xy, color='red')
     plt.scatter(x=lng, y=lat, c='red', edgecolors='black')
     plt.scatter(x=lng_snap, y=lat_snap, c='cyan', edgecolors='black')
-    plt.title('Flow Accumulation Grid for watershed id = {}'.format(wid))
+    plt.title(f'Flow Accumulation Grid for watershed id = {wid}')
     plt.xlabel('Longitude')
     plt.ylabel('Latitude')
-    plt.savefig("plots/{}_raster_accum.jpg".format(wid))
+    plt.savefig(f"{config.get('PLOTS_DIR')}/{wid}_raster_accum.jpg")
     plt.close(fig)
 
 
@@ -72,7 +74,7 @@ def plot_streams(streams, catchment_poly, lat, lng, lat_snap, lng_snap, wid, num
     plt.colorbar(label='Streams', fraction=0.06, pad=0.06)
     plt.xlabel('Longitude')
     plt.ylabel('Latitude')
-    plt.savefig("plots/{}_streams.jpg".format(wid))
+    plt.savefig(f"{config.get('PLOTS_DIR')}/{wid}_streams.jpg")
     plt.close(fig)
 
 
@@ -97,8 +99,8 @@ def plot_catchment(fdir, catchment_poly, result_polygon, lat, lng, lat_snap, lng
     plt.ylabel('Latitude')
     plt.scatter(x=lng, y=lat, c='red', edgecolors='black')
     plt.scatter(x=lng_snap, y=lat_snap, c='cyan', edgecolors='black', zorder=10)
-    plt.title('Delineated Raster Catchment for watershed id = {}'.format(wid))
-    plt.savefig("plots/{}_raster_catchment.jpg".format(wid))
+    plt.title(f'Delineated Raster Catchment for watershed id = {wid}')
+    plt.savefig(f"{config.get('PLOTS_DIR')}/{wid}_raster_catchment.jpg")
     plt.close(fig)
 
 
@@ -119,8 +121,8 @@ def plot_clipped(fdir, clipped_catch, catchment_poly, lat, lng, lat_snap, lng_sn
 
     plt.scatter(x=lng, y=lat, c='red', edgecolors='black')
     plt.scatter(x=lng_snap, y=lat_snap, c='cyan', edgecolors='black', zorder=10)
-    plt.title('Clipped Catchment for watershed id = {}'.format(wid))
-    plt.savefig("plots/{}_raster_catchment_and_poly.jpg".format(wid))
+    plt.title('Clipped Catchment for watershed id = {}')
+    plt.savefig(f"{config.get('PLOTS_DIR')}/{wid}_raster_catchment_and_poly.jpg")
     plt.close(fig)
 
 
@@ -151,5 +153,5 @@ def plot_polys(polygons: list, wid: str):
         color = np.random.rand(3, )
         gdf.loc[[x]].plot(edgecolor='gray', color=color, ax=ax)
 
-    plt.savefig(f"plots/{wid}_vector_catch_sub.jpg")
+    plt.savefig(f"{config.get('PLOTS_DIR')}/{wid}_vector_catch_sub.jpg")
     plt.close(fig)

--- a/upstream_delineator/py/consolidate.py
+++ b/upstream_delineator/py/consolidate.py
@@ -353,22 +353,22 @@ def consolidate_network(G: nx.DiGraph, threshold_area: float or int) -> Tuple[nx
     rivers2merge = {}
     rivers2delete = []
 
-    if DRAW_NET_DIAGRAM: draw_graph(G, filename='plots/test_net', title="Original Network")
+    if DRAW_NET_DIAGRAM: draw_graph(G, filename=f'{config.get("PLOTS_DIR")}/test_net', title="Original Network")
     if config.get("VERBOSE"):
         print(f"Consolidating river network. Max. subbasin area: {threshold_area}")
         print('Iteration #1')
 
     # Step 1, merge leaves with their downstream node
     G, MERGES, rivers2merge, rivers2delete = trim_clusters(G, threshold_area, MERGES, rivers2merge, rivers2delete)
-    if DRAW_NET_DIAGRAM: draw_graph(G, filename='plots/test_pruned', title="Pruned Network after Step 1")
+    if DRAW_NET_DIAGRAM: draw_graph(G, filename=f'{config.get("PLOTS_DIR")}/test_pruned', title="Pruned Network after Step 1")
 
     # Step 2, merge stems
     G, MERGES, rivers2merge = collapse_stems(G, threshold_area, MERGES, rivers2merge)
-    if DRAW_NET_DIAGRAM: draw_graph(G, filename='plots/test_step2', title="Stems merged, after Step 2")
+    if DRAW_NET_DIAGRAM: draw_graph(G, filename=f'{config.get("PLOTS_DIR")}/test_step2', title="Stems merged, after Step 2")
 
     # Step #3, prune small solo leaves
     G, MERGES, rivers2merge, rivers2delete = prune_leaves(G, threshold_area, MERGES, rivers2merge, rivers2delete)
-    if DRAW_NET_DIAGRAM: draw_graph(G, filename='plots/test_step4', title="Small solo leaves pruned, after Step 4")
+    if DRAW_NET_DIAGRAM: draw_graph(G, filename=f'{config.get("PLOTS_DIR")}/test_step4', title="Small solo leaves pruned, after Step 4")
 
     # Iterate through the consolidation steps until the network stops changing
     i = 1  # Counter to keep track of how many iterations we do
@@ -388,7 +388,7 @@ def consolidate_network(G: nx.DiGraph, threshold_area: float or int) -> Tuple[nx
     # Final step, takes care of any remaining small stem nodes
     G, MERGES, rivers2merge = last_merge(G, threshold_area, MERGES, rivers2merge)
 
-    if DRAW_NET_DIAGRAM:  draw_graph(G, filename='plots/test_step5', title="After iteration, Step 5")
+    if DRAW_NET_DIAGRAM:  draw_graph(G, filename=f'{config.get("PLOTS_DIR")}/test_step5', title="After iteration, Step 5")
     if config.get("VERBOSE"): show_area_stats(G)
 
     return G, MERGES, rivers2merge, rivers2delete


### PR DESCRIPTION
# description

the PLOTS_DIR flag wasn't working as expected

instead we were referencing a hardcoded plots directory everywhere we were plotting 

this fixes that by correctly using `config.get('PLOTS_DIR')` instead

part of https://app.asana.com/0/1201717938537096/1207922742449645/f 

# testing 

i can run `python upstream_delineator/scripts/subbasins.py outlets.csv test_plot_dir --PLOTS_DIR test_plot_dir --PLOTS`

and see the plots in the specified dir 

```
(venv) tngzng@tzhang:~/delineator$ ls -l test_plot_dir/
total 2676
-rw-rw-r-- 1 tngzng tngzng 195966 Aug 15 15:15 1_raster_accum.jpg
-rw-rw-r-- 1 tngzng tngzng 166723 Aug 15 15:15 1_raster_catchment_and_poly.jpg
-rw-rw-r-- 1 tngzng tngzng 196461 Aug 15 15:15 1_raster_flowdir.jpg
-rw-rw-r-- 1 tngzng tngzng  62046 Aug 15 15:15 1_raster_mask.jpg
-rw-rw-r-- 1 tngzng tngzng  63274 Aug 15 15:15 1_streams.jpg
-rw-rw-r-- 1 tngzng tngzng 128923 Aug 15 15:15 2_raster_accum.jpg
-rw-rw-r-- 1 tngzng tngzng 105210 Aug 15 15:15 2_raster_catchment_and_poly.jpg
-rw-rw-r-- 1 tngzng tngzng 119431 Aug 15 15:15 2_raster_flowdir.jpg
-rw-rw-r-- 1 tngzng tngzng  53473 Aug 15 15:15 2_raster_mask.jpg
-rw-rw-r-- 1 tngzng tngzng  54188 Aug 15 15:15 2_streams.jpg
-rw-rw-r-- 1 tngzng tngzng 130561 Aug 15 15:15 3_raster_accum.jpg
-rw-rw-r-- 1 tngzng tngzng 106879 Aug 15 15:15 3_raster_catchment_and_poly.jpg
-rw-rw-r-- 1 tngzng tngzng 122415 Aug 15 15:15 3_raster_flowdir.jpg
-rw-rw-r-- 1 tngzng tngzng  55091 Aug 15 15:15 3_raster_mask.jpg
-rw-rw-r-- 1 tngzng tngzng  55230 Aug 15 15:15 3_streams.jpg
-rw-rw-r-- 1 tngzng tngzng 126825 Aug 15 15:15 4_raster_accum.jpg
-rw-rw-r-- 1 tngzng tngzng 108292 Aug 15 15:15 4_raster_catchment_and_poly.jpg
-rw-rw-r-- 1 tngzng tngzng 122302 Aug 15 15:15 4_raster_flowdir.jpg
-rw-rw-r-- 1 tngzng tngzng  55158 Aug 15 15:15 4_raster_mask.jpg
-rw-rw-r-- 1 tngzng tngzng  59718 Aug 15 15:15 4_streams.jpg
-rw-rw-r-- 1 tngzng tngzng 130801 Aug 15 15:15 5_raster_accum.jpg
-rw-rw-r-- 1 tngzng tngzng 108382 Aug 15 15:15 5_raster_catchment_and_poly.jpg
-rw-rw-r-- 1 tngzng tngzng 122606 Aug 15 15:15 5_raster_flowdir.jpg
-rw-rw-r-- 1 tngzng tngzng  55621 Aug 15 15:15 5_raster_mask.jpg
-rw-rw-r-- 1 tngzng tngzng  61364 Aug 15 15:15 5_streams.jpg
-rw-rw-r-- 1 tngzng tngzng  52480 Aug 15 15:15 5_vector_catch_sub.jpg
-rw-rw-r-- 1 tngzng tngzng  77507 Aug 15 15:15 test_plot_dir_basins.png
```